### PR TITLE
Force HTTPS scheme in production environment

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,6 +19,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if ($this->app->environment('production')) {
+            \URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Added URL::forceScheme('https') in AppServiceProvider for production environment
- Ensures all generated URLs use HTTPS protocol when running in production
- Fixes mixed content issues when application runs behind proxy or load balancer

## Test plan
- [x] Verify all URLs are generated with HTTPS in production
- [x] Confirm no impact on local development environment
- [x] Test that assets load correctly without mixed content warnings

🤖 Generated with [Claude Code](https://claude.ai/code)