### PR TITLE
Fix repository name truncation bug

### DIFF
--- a/app/Http/Controllers/RepositoryController.php
+++ b/app/Http/Controllers/RepositoryController.php
@@ -165,7 +165,9 @@ class RepositoryController extends Controller
     private function extractRepoName(string $url): string
     {
         // Remove trailing .git if present
-        $url = rtrim($url, '.git');
+        if (str_ends_with($url, '.git')) {
+            $url = substr($url, 0, -4);
+        }
 
         // Extract repository name from URL
         $parts = explode('/', $url);


### PR DESCRIPTION
## Summary
- Fixed incorrect use of `rtrim()` that was truncating repository names ending with letters in 'g', 'i', 't'
- Changed to use `str_ends_with()` and `substr()` for proper `.git` suffix removal

## Problem
When adding a repository like `https://github.com/CodingCab/LaraChat`, the name was being truncated to "LaraCha" instead of "LaraChat". This was because `rtrim($url, '.git')` removes any trailing characters that match any character in the string '.git', not just the literal ".git" suffix.

## Solution
Replaced `rtrim($url, '.git')` with a proper check using `str_ends_with()` and `substr()` to only remove the ".git" suffix when it's actually present at the end of the URL.

## Test plan
- [x] Tested with repository URL `https://github.com/CodingCab/LaraChat` - correctly extracts "LaraChat"
- [x] Tested with repository URL `https://github.com/CodingCab/LaraChat.git` - correctly extracts "LaraChat"
- [x] Tested with other repository names to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)