### PR TITLE
Update CopyRepositoryToHotJob to fetch latest changes before copying

### DIFF
--- a/app/Jobs/CopyRepositoryToHotJob.php
+++ b/app/Jobs/CopyRepositoryToHotJob.php
@@ -9,6 +9,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class CopyRepositoryToHotJob implements ShouldQueue
 {
@@ -37,6 +39,44 @@ class CopyRepositoryToHotJob implements ShouldQueue
             return;
         }
 
+        try {
+            $this->runGitCommand('checkout master', $basePath);
+            $this->runGitCommand('fetch', $basePath);
+            $this->runGitCommand('reset --hard origin/master', $basePath);
+            
+            Log::info('CopyRepositoryToHot: Updated base repository to latest version', [
+                'repository' => $this->repository,
+            ]);
+        } catch (ProcessFailedException $e) {
+            Log::error('CopyRepositoryToHot: Failed to update base repository', [
+                'repository' => $this->repository,
+                'error' => $e->getMessage(),
+                'output' => $e->getProcess()->getErrorOutput()
+            ]);
+            
+            throw $e;
+        }
+
         File::copyDirectory($basePath, $hotPath);
+        
+        Log::info('CopyRepositoryToHot: Successfully copied repository to hot', [
+            'repository' => $this->repository,
+        ]);
+    }
+    
+    protected function runGitCommand(string $command, string $workingDirectory): Process
+    {
+        $fullCommand = 'git ' . $command;
+        
+        $process = Process::fromShellCommandline($fullCommand);
+        $process->setWorkingDirectory($workingDirectory);
+        $process->setTimeout(60);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        return $process;
     }
 }


### PR DESCRIPTION
## Summary
- Added git operations to ensure the base repository is up-to-date before copying to hot directory
- Mirrors the system update approach with `git checkout master`, `git fetch`, and `git reset --hard origin/master`
- Added error handling and logging for better debugging

## Changes
- Added `runGitCommand()` method to execute git commands with proper error handling
- Updated `handle()` method to fetch latest changes before copying
- Added logging for successful updates and error scenarios
- Added Process and ProcessFailedException imports

## Test plan
- [ ] Verify the job successfully updates the base repository before copying
- [ ] Test error handling when git operations fail
- [ ] Confirm hot directory contains the latest version after job execution

🤖 Generated with [Claude Code](https://claude.ai/code)