### PR TITLE
Refactor conversation initialization into separate job

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -3,17 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Jobs\CopyRepositoryToHotJob;
+use App\Jobs\InitializeConversationSessionJob;
 use App\Jobs\PrepareProjectDirectoryJob;
 use App\Jobs\SendClaudeMessageJob;
 use App\Models\Conversation;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
+use Illuminate\Support\Facades\Bus;
 
 class ConversationsController extends Controller
 {
@@ -60,73 +57,14 @@ class ConversationsController extends Controller
             'is_processing' => true, // Mark as processing when created
         ]);
 
-        // Initialize session with the user's message (but no Claude response)
-        $sessionData = [
-            [
-                "sessionId" => null,
-                'role' => 'user',
-                'userMessage' => $msg,
-                'timestamp' => now()->toIso8601String(),
-                "isComplete" => false,
-                "repositoryPath" => null,
-            ]
-        ];
-
-        Storage::put($conversation->filename, json_encode($sessionData, JSON_PRETTY_PRINT));
-
-        $from = storage_path( 'app/private/repositories/hot/' . $conversation->repository);
-
-        if (!File::exists($from)) {
-            CopyRepositoryToHotJob::dispatchSync($conversation->repository);
-        }
-
-        $to = storage_path($conversation->project_directory);
-
-        ray($from, $to);
-        File::moveDirectory($from, $to, true);
-
-        // Update the Git repository in the moved directory
-        try {
-            $this->runGitCommand('checkout master', $to);
-            $this->runGitCommand('fetch', $to);
-            $this->runGitCommand('reset --hard origin/master', $to);
-            
-            Log::info('ConversationsController: Updated project repository to latest version', [
-                'repository' => $conversation->repository,
-                'project_directory' => $conversation->project_directory,
-            ]);
-        } catch (ProcessFailedException $e) {
-            Log::error('ConversationsController: Failed to update project repository', [
-                'repository' => $conversation->repository,
-                'project_directory' => $conversation->project_directory,
-                'error' => $e->getMessage(),
-                'output' => $e->getProcess()->getErrorOutput()
-            ]);
-            
-            // Continue with the conversation even if Git update fails
-            // The repository is still functional, just might not be on latest
-        }
-
-        SendClaudeMessageJob::dispatch($conversation, $msg);;
+        Bus::chain([
+            new InitializeConversationSessionJob($conversation, $msg),
+            new SendClaudeMessageJob($conversation, $msg)
+        ]);
 
         CopyRepositoryToHotJob::dispatch($conversation->repository);
 
         return redirect()->route('claude.conversation', $conversation->id);
     }
 
-    protected function runGitCommand(string $command, string $workingDirectory): Process
-    {
-        $fullCommand = 'git ' . $command;
-        
-        $process = Process::fromShellCommandline($fullCommand);
-        $process->setWorkingDirectory($workingDirectory);
-        $process->setTimeout(60);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
-            throw new ProcessFailedException($process);
-        }
-
-        return $process;
-    }
 }

--- a/app/Jobs/InitializeConversationSessionJob.php
+++ b/app/Jobs/InitializeConversationSessionJob.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Conversation;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class InitializeConversationSessionJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        protected Conversation $conversation,
+        protected string $message
+    ) {}
+
+    public function handle(): void
+    {
+        // Initialize session with the user's message (but no Claude response)
+        $sessionData = [
+            [
+                "sessionId" => null,
+                'role' => 'user',
+                'userMessage' => $this->message,
+                'timestamp' => now()->toIso8601String(),
+                "isComplete" => false,
+                "repositoryPath" => null,
+            ]
+        ];
+
+        Storage::put($this->conversation->filename, json_encode($sessionData, JSON_PRETTY_PRINT));
+
+        $from = storage_path('app/private/repositories/hot/' . $this->conversation->repository);
+
+        if (!File::exists($from)) {
+            CopyRepositoryToHotJob::dispatchSync($this->conversation->repository);
+        }
+
+        $to = storage_path($this->conversation->project_directory);
+
+        ray($from, $to);
+        File::moveDirectory($from, $to, true);
+
+        // Update the Git repository in the moved directory
+        try {
+            $this->runGitCommand('checkout master', $to);
+            $this->runGitCommand('fetch', $to);
+            $this->runGitCommand('reset --hard origin/master', $to);
+            
+            Log::info('InitializeConversationSessionJob: Updated project repository to latest version', [
+                'repository' => $this->conversation->repository,
+                'project_directory' => $this->conversation->project_directory,
+            ]);
+        } catch (ProcessFailedException $e) {
+            Log::error('InitializeConversationSessionJob: Failed to update project repository', [
+                'repository' => $this->conversation->repository,
+                'project_directory' => $this->conversation->project_directory,
+                'error' => $e->getMessage(),
+                'output' => $e->getProcess()->getErrorOutput()
+            ]);
+            
+            // Continue with the conversation even if Git update fails
+            // The repository is still functional, just might not be on latest
+        }
+    }
+
+    protected function runGitCommand(string $command, ?string $cwd = null): void
+    {
+        $gitCommand = "git {$command}";
+        
+        $result = Process::path($cwd ?? base_path())
+            ->run($gitCommand);
+        
+        if (!$result->successful()) {
+            throw new ProcessFailedException($result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted session initialization logic from ConversationsController into a dedicated InitializeConversationSessionJob
- Implemented job chaining to ensure proper execution order between initialization and Claude message sending
- Improved code organization and maintainability

## Changes
- Created `InitializeConversationSessionJob` to handle:
  - Session data initialization
  - Storage of session JSON file
  - Repository directory movement from hot to project location
  - Git repository sync (checkout, fetch, reset to latest)
  
- Updated `ConversationsController` to:
  - Use job chaining with `Bus::chain()` for sequential execution
  - Remove inline initialization logic
  - Clean up unused imports and methods

## Benefits
- Better separation of concerns
- Improved error handling and logging
- Easier testing and maintenance
- Jobs can be retried independently if failures occur

## Test plan
- [ ] Verify new conversations are created successfully
- [ ] Confirm session files are properly initialized
- [ ] Check that repositories are moved to correct project directories
- [ ] Ensure Git sync works as expected
- [ ] Validate job chaining executes in correct order

🤖 Generated with [Claude Code](https://claude.ai/code)