### PR TITLE
Fix job chain dispatch and directory handling issues

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -60,7 +60,7 @@ class ConversationsController extends Controller
         Bus::chain([
             new InitializeConversationSessionJob($conversation, $msg),
             new SendClaudeMessageJob($conversation, $msg)
-        ]);
+        ])->dispatch();
 
         CopyRepositoryToHotJob::dispatch($conversation->repository);
 


### PR DESCRIPTION
## Summary
- Fixed job chain not executing due to missing `dispatch()` call
- Added proper directory handling to prevent RuntimeException
- Improved error handling and logging

## Problem
The refactored job chain wasn't executing because `Bus::chain()` creates a chain but doesn't dispatch it. Additionally, the job was throwing a RuntimeException when trying to run git commands in a non-existent directory.

## Solution
1. **Job Chain Dispatch**: Added `->dispatch()` to `Bus::chain()` to actually execute the job chain
2. **Directory Handling**: 
   - Ensure parent directory exists before attempting to move repository
   - Validate that directory move was successful before running git commands
   - Return early with error logging if directory doesn't exist after move

## Changes
- `ConversationsController.php`: Added `->dispatch()` to job chain
- `InitializeConversationSessionJob.php`:
  - Create parent directory structure if it doesn't exist
  - Check if directory exists after move operation
  - Add error logging for failed directory moves
  - Return early to prevent RuntimeException

## Error Fixed
```
Symfony\Component\Process\Exception\RuntimeException: 
The provided cwd "/Users/.../storage/app/private/repositories/projects/68991dfd01798" does not exist.
```

## Test plan
- [ ] Verify job chain executes properly
- [ ] Confirm new conversations are created without errors
- [ ] Check that parent directories are created as needed
- [ ] Validate error logging works for failed moves
- [ ] Ensure git commands only run when directory exists

🤖 Generated with [Claude Code](https://claude.ai/code)