### PR TITLE
Improve claude-wrapper script to run from project directory

### DIFF
--- a/claude-wrapper.sh
+++ b/claude-wrapper.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change to the project directory
+cd "$SCRIPT_DIR" || exit 1
+
 # Set up environment for Claude CLI
 export PATH="/Users/arturhanusek/Library/Application Support/Herd/config/nvm/versions/node/v22.17.1/bin:$PATH"
 export HOME="/Users/arturhanusek"
 export USER="arturhanusek"
 
-# Execute claude with all arguments
+# Execute claude with all arguments from the project directory
 exec claude "$@"


### PR DESCRIPTION
## Summary
- Enhanced claude-wrapper.sh to automatically change to the project directory before executing claude
- Added script directory detection using BASH_SOURCE for reliable path resolution
- Ensures claude always runs in the correct project context regardless of where the wrapper is invoked

## Test plan
- [ ] Execute claude-wrapper.sh from various directories
- [ ] Verify claude runs in the project directory context
- [ ] Confirm all claude commands work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)