### PR TITLE
Fix Claude message sending by removing hardcoded user paths

### DIFF
--- a/claude-wrapper.sh
+++ b/claude-wrapper.sh
@@ -25,9 +25,10 @@ fi
 cd "$PROJECT_DIR" || exit 1
 
 # Set up environment for Claude CLI
-export PATH="/Users/arturhanusek/Library/Application Support/Herd/config/nvm/versions/node/v22.17.1/bin:$PATH"
-export HOME="/Users/arturhanusek"
-export USER="arturhanusek"
+# Use the actual user's environment
+export PATH="/opt/homebrew/bin:$PATH"
+export HOME="${HOME:-/Users/customer}"
+export USER="${USER:-customer}"
 
 # Execute claude with all arguments from the project directory
 exec claude "$@"


### PR DESCRIPTION
## Summary
- Fixed message sending failure by removing hardcoded user paths from `claude-wrapper.sh`
- Messages were failing to process because the wrapper script was hardcoded for a specific user

## Problem
The `claude-wrapper.sh` script contained hardcoded paths for user `arturhanusek`, which caused the Claude CLI to fail when run by other users or service accounts. This prevented messages from being processed through the queue system.

## Solution
Updated the wrapper script to use dynamic environment variables:
- `HOME` and `USER` now use the actual system user's values
- `PATH` updated to use standard homebrew location (`/opt/homebrew/bin`)
- Falls back to reasonable defaults if environment variables are not set

## Testing
- [x] Verified wrapper script works with dynamic user paths
- [x] Tested with `./claude-wrapper.sh default --version`
- [x] Queue workers restarted to pick up changes
- [x] Messages now process successfully through the queue

## Impact
This fix ensures the Claude message processing works for all users, not just the originally hardcoded user.

🤖 Generated with [Claude Code](https://claude.ai/code)