### PR TITLE
feat: Add general webhook endpoint for creating conversations via API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ ANTHROPIC_API_KEY=
 # GitHub Webhook Configuration
 GITHUB_WEBHOOK_SECRET=
 
+# General Webhook Configuration
+WEBHOOK_SECRET=
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\CopyRepositoryToHotJob;
+use App\Jobs\InitializeConversationSessionJob;
+use App\Jobs\SendClaudeMessageJob;
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+
+class WebhookController extends Controller
+{
+    public function handle(Request $request)
+    {
+        $payload = $request->getContent();
+        $signature = $request->header('X-Webhook-Signature');
+
+        if (!$this->verifyWebhookSignature($payload, $signature)) {
+            Log::warning('Webhook signature verification failed');
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $data = json_decode($payload, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            Log::warning('Webhook received invalid JSON payload');
+            return response()->json(['error' => 'Invalid JSON payload'], 400);
+        }
+
+        // Validate required fields
+        if (empty($data['message'])) {
+            return response()->json(['error' => 'Missing required field: message'], 422);
+        }
+
+        try {
+            // Get the user for the conversation - either from the webhook data or use a default webhook user
+            $user = null;
+            if (!empty($data['user_email'])) {
+                $user = User::where('email', $data['user_email'])->first();
+            }
+            
+            // If no user found, use or create a default webhook user
+            if (!$user) {
+                $user = User::firstOrCreate(
+                    ['email' => 'webhook@system.local'],
+                    [
+                        'name' => 'Webhook System',
+                        'password' => bcrypt(bin2hex(random_bytes(32))), // Random password
+                    ]
+                );
+            }
+
+            $project_id = uniqid();
+            $message = $data['message'];
+            $repository = $data['repository'] ?? null;
+            
+            // Get base project directory from .env
+            $baseProjectDirectory = env('PROJECT_DIRECTORY', 'app/private/repositories');
+            $projectDirectory = rtrim($baseProjectDirectory, '/') . '/' . $project_id;
+
+            // Create conversation
+            $conversation = Conversation::create([
+                'user_id' => $user->id,
+                'title' => substr($message, 0, 100) . (strlen($message) > 100 ? '...' : ''),
+                'message' => $message,
+                'claude_session_id' => null, // Let Claude generate this
+                'project_directory' => $projectDirectory,
+                'repository' => $repository,
+                'filename' => 'claude-sessions/' . date('Y-m-d\TH-i-s') . '-session-' . $project_id . '.json',
+                'is_processing' => true, // Mark as processing when created
+            ]);
+
+            // Dispatch jobs to process the conversation
+            Bus::chain([
+                new InitializeConversationSessionJob($conversation, $message),
+                new SendClaudeMessageJob($conversation, $message)
+            ])->dispatch();
+
+            if ($repository) {
+                CopyRepositoryToHotJob::dispatch($repository);
+            }
+
+            Log::info('Webhook created new conversation', [
+                'conversation_id' => $conversation->id,
+                'user_id' => $user->id,
+                'repository' => $repository,
+            ]);
+
+            return response()->json([
+                'status' => 'success',
+                'conversation_id' => $conversation->id,
+                'message' => 'Conversation created successfully',
+            ], 201);
+
+        } catch (\Exception $e) {
+            Log::error('Webhook conversation creation failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json(['error' => 'Failed to create conversation'], 500);
+        }
+    }
+
+    private function verifyWebhookSignature($payload, $signature)
+    {
+        if (empty($signature)) {
+            return false;
+        }
+
+        $secret = config('services.webhook.secret');
+        if (empty($secret)) {
+            Log::warning('Webhook secret not configured');
+            return false;
+        }
+
+        // Support both plain secret comparison and HMAC signatures
+        // For HMAC: signature should be in format "sha256=<hash>"
+        if (strpos($signature, 'sha256=') === 0) {
+            $expected = 'sha256=' . hash_hmac('sha256', $payload, $secret);
+            return hash_equals($expected, $signature);
+        }
+
+        // For simple secret comparison
+        return hash_equals($secret, $signature);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -39,4 +39,8 @@ return [
         'webhook_secret' => env('GITHUB_WEBHOOK_SECRET'),
     ],
 
+    'webhook' => [
+        'secret' => env('WEBHOOK_SECRET'),
+    ],
+
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\CommandController;
 use App\Http\Controllers\ConversationsController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\RepositoryController;
+use App\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['web', 'auth'])->group(function () {
@@ -27,3 +28,5 @@ Route::middleware(['web', 'auth'])->group(function () {
 
 Route::post('/github/webhook', [GitHubWebhookController::class, 'handle']);
 Route::get('/github/webhook', [GitHubWebhookController::class, 'handle']);
+
+Route::post('/webhooks', [WebhookController::class, 'handle']);

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class WebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.webhook.secret' => 'test-webhook-secret']);
+    }
+
+    public function test_webhook_requires_valid_signature()
+    {
+        $payload = json_encode(['message' => 'Test message']);
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true));
+        
+        $response->assertStatus(401)
+            ->assertJson(['error' => 'Unauthorized']);
+    }
+
+    public function test_webhook_accepts_valid_hmac_signature()
+    {
+        Queue::fake();
+        
+        $payload = json_encode([
+            'message' => 'Test webhook message',
+            'repository' => 'test-repo',
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'status',
+                'conversation_id',
+                'message',
+            ])
+            ->assertJson(['status' => 'success']);
+        
+        $this->assertDatabaseHas('conversations', [
+            'message' => 'Test webhook message',
+            'repository' => 'test-repo',
+        ]);
+    }
+
+    public function test_webhook_accepts_valid_plain_signature()
+    {
+        Queue::fake();
+        
+        $payload = json_encode([
+            'message' => 'Test webhook message with plain signature',
+        ]);
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => 'test-webhook-secret',
+        ]);
+        
+        $response->assertStatus(201)
+            ->assertJson(['status' => 'success']);
+        
+        $this->assertDatabaseHas('conversations', [
+            'message' => 'Test webhook message with plain signature',
+        ]);
+    }
+
+    public function test_webhook_creates_conversation_with_user_email()
+    {
+        Queue::fake();
+        
+        $user = User::factory()->create(['email' => 'test@example.com']);
+        
+        $payload = json_encode([
+            'message' => 'Test message with user',
+            'user_email' => 'test@example.com',
+            'repository' => 'user-repo',
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(201);
+        
+        $conversation = Conversation::where('message', 'Test message with user')->first();
+        $this->assertNotNull($conversation);
+        $this->assertEquals($user->id, $conversation->user_id);
+        $this->assertEquals('user-repo', $conversation->repository);
+    }
+
+    public function test_webhook_creates_default_user_if_email_not_found()
+    {
+        Queue::fake();
+        
+        $payload = json_encode([
+            'message' => 'Test message without user',
+            'user_email' => 'nonexistent@example.com',
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(201);
+        
+        $webhookUser = User::where('email', 'webhook@system.local')->first();
+        $this->assertNotNull($webhookUser);
+        $this->assertEquals('Webhook System', $webhookUser->name);
+        
+        $conversation = Conversation::where('message', 'Test message without user')->first();
+        $this->assertNotNull($conversation);
+        $this->assertEquals($webhookUser->id, $conversation->user_id);
+    }
+
+    public function test_webhook_requires_message_field()
+    {
+        $payload = json_encode([
+            'repository' => 'test-repo',
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing required field: message']);
+    }
+
+    public function test_webhook_handles_invalid_json()
+    {
+        $response = $this->call('POST', '/api/webhooks', [], [], [], [
+            'HTTP_X-Webhook-Signature' => 'test-webhook-secret',
+        ], 'invalid-json');
+        
+        $response->assertStatus(400)
+            ->assertJson(['error' => 'Invalid JSON payload']);
+    }
+
+    public function test_webhook_handles_long_messages()
+    {
+        Queue::fake();
+        
+        $longMessage = str_repeat('This is a very long message. ', 100);
+        
+        $payload = json_encode([
+            'message' => $longMessage,
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(201);
+        
+        $conversation = Conversation::latest()->first();
+        $this->assertNotNull($conversation);
+        $this->assertEquals($longMessage, $conversation->message);
+        // Title should be truncated to 100 chars + '...'
+        $this->assertLessThanOrEqual(103, strlen($conversation->title));
+    }
+
+    public function test_webhook_works_without_repository()
+    {
+        Queue::fake();
+        
+        $payload = json_encode([
+            'message' => 'Test message without repository',
+        ]);
+        
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, 'test-webhook-secret');
+        
+        $response = $this->postJson('/api/webhooks', json_decode($payload, true), [
+            'X-Webhook-Signature' => $signature,
+        ]);
+        
+        $response->assertStatus(201);
+        
+        $conversation = Conversation::where('message', 'Test message without repository')->first();
+        $this->assertNotNull($conversation);
+        $this->assertNull($conversation->repository);
+    }
+}


### PR DESCRIPTION
## Summary
Implements a new `/api/webhooks` endpoint that allows external services to create conversations programmatically, similar to GitHub webhooks but for general use.

## Features

### 🔐 Security
- Protected by configurable secret (`WEBHOOK_SECRET` in `.env`)
- Supports two authentication methods:
  - **HMAC signature**: `sha256=<hash>` for secure webhook validation
  - **Plain secret**: Direct secret comparison for simpler integrations

### 📝 API Endpoint
**URL**: `POST /api/webhooks`

**Headers**:
```
Content-Type: application/json
X-Webhook-Signature: <signature>
```

**Request Body**:
```json
{
  "message": "Required message text",
  "repository": "optional-repository-name",
  "user_email": "optional@email.com"
}
```

**Response** (201 Created):
```json
{
  "status": "success",
  "conversation_id": 123,
  "message": "Conversation created successfully"
}
```

### 👤 User Handling
- If `user_email` is provided and exists, conversation is assigned to that user
- If email doesn't exist or isn't provided, uses/creates a system webhook user
- System user: `webhook@system.local` (Webhook System)

## Implementation Details

### Files Changed
- `app/Http/Controllers/WebhookController.php` - Main webhook handler
- `routes/api.php` - Added POST /api/webhooks route
- `config/services.php` - Added webhook configuration
- `.env.example` - Added WEBHOOK_SECRET example
- `tests/Feature/WebhookTest.php` - Comprehensive test coverage

### Configuration
Add to `.env`:
```
WEBHOOK_SECRET=your-secret-here
```

## Testing

### Test Coverage
✅ 9 comprehensive tests covering:
- Signature validation (both HMAC and plain)
- User creation and association
- Missing field validation
- Invalid JSON handling
- Long message handling
- Repository optional field
- Default user creation

### Running Tests
```bash
php artisan test --filter=WebhookTest
```

All tests passing:
```
Tests:    9 passed (40 assertions)
```

## Usage Examples

### With HMAC Signature (Recommended)
```bash
payload='{"message": "Hello Claude", "repository": "my-repo"}'
signature=$(echo -n "$payload" | openssl dgst -sha256 -hmac "your-secret" | cut -d' ' -f2)

curl -X POST https://your-domain.com/api/webhooks \
  -H "Content-Type: application/json" \
  -H "X-Webhook-Signature: sha256=$signature" \
  -d "$payload"
```

### With Plain Secret (Simple)
```bash
curl -X POST https://your-domain.com/api/webhooks \
  -H "Content-Type: application/json" \
  -H "X-Webhook-Signature: your-secret" \
  -d '{"message": "Hello Claude"}'
```

### With User Association
```bash
curl -X POST https://your-domain.com/api/webhooks \
  -H "Content-Type: application/json" \
  -H "X-Webhook-Signature: your-secret" \
  -d '{
    "message": "Process this data",
    "user_email": "john@example.com",
    "repository": "data-repo"
  }'
```

## Use Cases
- CI/CD pipelines triggering Claude analysis
- Monitoring systems requesting AI insights
- Third-party integrations
- Automated reporting systems
- Custom chatbots and integrations

## Security Considerations
- Always use HTTPS in production
- Use strong, randomly generated secrets
- Consider using HMAC signatures for production
- Rotate secrets periodically
- Monitor webhook usage for anomalies

🤖 Generated with [Claude Code](https://claude.ai/code)