### PR TITLE
Add conversation archiving functionality

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -17,6 +17,7 @@ class ConversationsController extends Controller
     public function index()
     {
         $conversations = Conversation::where('user_id', Auth::id())
+            ->where('archived', false)
             ->orderBy('updated_at', 'desc')
             ->get();
 
@@ -69,6 +70,42 @@ class ConversationsController extends Controller
         CopyRepositoryToHotJob::dispatch($conversation->repository);
 
         return redirect()->route('claude.conversation', $conversation->id);
+    }
+
+    public function archive(Conversation $conversation)
+    {
+        // Ensure the user owns this conversation
+        if ($conversation->user_id !== Auth::id()) {
+            return response()->json(['error' => 'Unauthorized'], 403);
+        }
+
+        $conversation->archived = true;
+        $conversation->save();
+
+        return response()->json(['message' => 'Conversation archived successfully']);
+    }
+
+    public function unarchive(Conversation $conversation)
+    {
+        // Ensure the user owns this conversation
+        if ($conversation->user_id !== Auth::id()) {
+            return response()->json(['error' => 'Unauthorized'], 403);
+        }
+
+        $conversation->archived = false;
+        $conversation->save();
+
+        return response()->json(['message' => 'Conversation unarchived successfully']);
+    }
+
+    public function archived()
+    {
+        $conversations = Conversation::where('user_id', Auth::id())
+            ->where('archived', true)
+            ->orderBy('updated_at', 'desc')
+            ->get();
+
+        return response()->json($conversations);
     }
 
 }

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $claude_session_id
  * @property string|null $filename
  * @property bool $is_processing
+ * @property bool $archived
  */
 class Conversation extends Model
 {
@@ -29,6 +30,12 @@ class Conversation extends Model
         'claude_session_id',
         'filename',
         'is_processing',
+        'archived',
+    ];
+
+    protected $casts = [
+        'is_processing' => 'boolean',
+        'archived' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/database/migrations/2025_08_14_add_archived_to_conversations_table.php
+++ b/database/migrations/2025_08_14_add_archived_to_conversations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->boolean('archived')->default(false)->after('is_processing');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropColumn('archived');
+        });
+    }
+};

--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -13,9 +13,10 @@ import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { extractTextFromResponse } from '@/utils/claudeResponseParser';
 import { router } from '@inertiajs/vue3';
-import { Eye, EyeOff, Send } from 'lucide-vue-next';
+import { Eye, EyeOff, Send, Archive, ArchiveRestore } from 'lucide-vue-next';
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { GitBranch } from 'lucide-vue-next';
+import axios from 'axios';
 
 // Constants
 const POLLING_INTERVAL_MS = 2000;
@@ -29,6 +30,7 @@ const props = defineProps<{
     repository?: string;
     conversationId?: number;
     sessionId?: string;
+    isArchived?: boolean;
 }>();
 
 const breadcrumbs = computed<BreadcrumbItem[]>(() => {
@@ -64,6 +66,8 @@ const hideSystemMessages = ref(true);
 const selectedRepository = ref<string | null>(props.repository || null);
 const isUserInteracting = ref(false);
 const pendingUpdates = ref<any[]>([]);
+const isArchived = ref(props.isArchived || false);
+const isArchiving = ref(false);
 
 // Polling state
 const pollingInterval = ref<number | null>(null);
@@ -496,6 +500,43 @@ const handleKeydown = (event: KeyboardEvent) => {
     }
 };
 
+const archiveConversation = async () => {
+    if (!conversationId.value || isArchiving.value) return;
+    
+    isArchiving.value = true;
+    try {
+        await axios.post(`/api/conversations/${conversationId.value}/archive`);
+        isArchived.value = true;
+        
+        // Refresh conversations list to update sidebar
+        await fetchConversations(false, true);
+        
+        // Redirect to main Claude page after archiving
+        router.visit('/claude');
+    } catch (error) {
+        console.error('Error archiving conversation:', error);
+    } finally {
+        isArchiving.value = false;
+    }
+};
+
+const unarchiveConversation = async () => {
+    if (!conversationId.value || isArchiving.value) return;
+    
+    isArchiving.value = true;
+    try {
+        await axios.post(`/api/conversations/${conversationId.value}/unarchive`);
+        isArchived.value = false;
+        
+        // Refresh conversations list to update sidebar
+        await fetchConversations(false, true);
+    } catch (error) {
+        console.error('Error unarchiving conversation:', error);
+    } finally {
+        isArchiving.value = false;
+    }
+};
+
 // Watchers
 watch(() => props.sessionFile, async (newFile, oldFile) => {
     if (newFile !== oldFile) {
@@ -576,6 +617,17 @@ onUnmounted(() => {
     <AppLayout :breadcrumbs="breadcrumbs">
         <template #header-actions>
             <Button
+                v-if="conversationId"
+                @click="isArchived ? unarchiveConversation() : archiveConversation()"
+                variant="ghost"
+                size="icon"
+                :title="isArchived ? 'Unarchive Conversation' : 'Archive Conversation'"
+                :disabled="isArchiving"
+                class="mr-2"
+            >
+                <component :is="isArchived ? ArchiveRestore : Archive" class="h-4 w-4" />
+            </Button>
+            <Button
                 @click="hideSystemMessages = !hideSystemMessages"
                 variant="ghost"
                 size="icon"
@@ -614,7 +666,10 @@ onUnmounted(() => {
 
             <!-- Input Area -->
             <div class="border-t bg-background p-4">
-                <div>
+                <div v-if="isArchived" class="text-center text-muted-foreground">
+                    This conversation is archived. Unarchive it to continue the conversation.
+                </div>
+                <div v-else>
                     <div class="flex items-end space-x-2">
                         <Textarea
                             ref="textareaRef"

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,9 @@ Route::middleware(['web', 'auth'])->group(function () {
 
     Route::get('/conversations', [ConversationsController::class, 'index']);
     Route::post('/conversations', [ConversationsController::class, 'store']);
+    Route::get('/conversations/archived', [ConversationsController::class, 'archived']);
+    Route::post('/conversations/{conversation}/archive', [ConversationsController::class, 'archive']);
+    Route::post('/conversations/{conversation}/unarchive', [ConversationsController::class, 'unarchive']);
 
     Route::get('/claude/conversations', [ConversationsController::class, 'index']); // TODO: deprecated, replace usage with /conversations
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,8 @@ Route::get('claude/conversation/{conversation}', function ($conversation) {
         'conversationId' => $conv->id,
         'repository' => $conv->repository,
         'sessionId' => $conv->claude_session_id,
-        'sessionFile' => $conv->filename
+        'sessionFile' => $conv->filename,
+        'isArchived' => $conv->archived ?? false
     ]);
 })->middleware(['auth', 'verified'])->name('claude.conversation');
 


### PR DESCRIPTION
## Summary
- Adds the ability to archive and unarchive conversations
- Archived conversations are hidden from the main conversation list
- Users can access archived conversations through a dedicated endpoint

## Changes
- Added `archived` boolean column to conversations table via migration
- Updated `ConversationsController` to filter out archived conversations from main list
- Added archive/unarchive API endpoints with proper authorization checks
- Updated Claude.vue with archive/unarchive UI buttons in the header
- Added visual indicator when viewing an archived conversation

## Test plan
- [x] Archive a conversation and verify it disappears from the sidebar
- [x] Unarchive a conversation and verify it reappears in the sidebar
- [x] Verify archived conversations cannot be continued until unarchived
- [x] Test authorization - users can only archive their own conversations

🤖 Generated with [Claude Code](https://claude.ai/code)