### PR TITLE
Fix archive button state not resetting on conversation change

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -555,6 +555,19 @@ watch(() => props.repository, (newRepo) => {
     selectedRepository.value = newRepo || null;
 }, { immediate: true });
 
+// Reset archive state when conversation changes
+watch(() => props.conversationId, (newId) => {
+    conversationId.value = newId || null;
+    // Reset archive button state when conversation changes
+    isArchived.value = props.isArchived || false;
+    isArchiving.value = false;
+});
+
+// Update archive state when prop changes
+watch(() => props.isArchived, (newValue) => {
+    isArchived.value = newValue || false;
+});
+
 // Lifecycle
 onMounted(async () => {
     // Set up global selection tracking


### PR DESCRIPTION
## Summary
- Fixed archive button state not resetting when switching between conversations
- Added watchers to properly handle conversation and archive state changes
- Ensures archive button always shows correct state for current conversation

## Changes
- Added `watch` for `props.conversationId` to reset archive states when conversation changes
- Added `watch` for `props.isArchived` to sync archive state with prop updates
- Reset both `isArchived` and `isArchiving` states on conversation change

## Test plan
- [x] Switch between different conversations and verify archive button state resets
- [x] Archive a conversation and verify button changes to "Unarchive"
- [x] Navigate to a different conversation and verify button shows correct state
- [x] Return to archived conversation and verify it still shows "Unarchive"

🤖 Generated with [Claude Code](https://claude.ai/code)