### PR TITLE
Auto-scroll to bottom when opening conversations

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -358,7 +358,8 @@ const loadSessionMessages = async (isPolling = false) => {
         
         // Only scroll if not interacting
         if (!isUserInteracting.value) {
-            await delayedScroll(false);
+            // Force scroll to bottom on initial load, otherwise use smart scrolling
+            await delayedScroll(!isPolling);
         }
 
         // Manage polling based on completion status
@@ -544,6 +545,8 @@ watch(() => props.sessionFile, async (newFile, oldFile) => {
 
         if (newFile) {
             await loadSessionMessages();
+            // Force scroll to bottom when switching to a different conversation
+            await scrollToBottom(true);
         } else {
             sessionFilename.value = null;
             sessionId.value = null;
@@ -588,6 +591,8 @@ onMounted(async () => {
 
     if (props.sessionFile) {
         await loadSessionMessages();
+        // Force scroll to bottom when opening an existing conversation
+        await scrollToBottom(true);
     } else if (props.conversationId) {
         // For conversation-based pages, we'll need to wait for the session file
         // Start polling immediately to check for session file


### PR DESCRIPTION
## Summary
- Automatically scrolls to the bottom of chat when opening conversations
- Ensures users see the latest messages immediately without manual scrolling
- Improves user experience when navigating between conversations

## Changes
- Modified `loadSessionMessages()` to force scroll on initial load
- Added force scroll when mounting component with existing session
- Added force scroll when switching between different conversations via the watcher

## Test plan
- [x] Open an existing conversation - should scroll to bottom automatically
- [x] Switch between different conversations - should scroll to bottom each time
- [x] Send a new message - should maintain existing scroll behavior
- [x] During polling updates - respects user's scroll position (only scrolls if already at bottom)

🤖 Generated with [Claude Code](https://claude.ai/code)