### PR TITLE
Refactor: Simplify Jobs page UI layout

### DIFF
--- a/resources/js/pages/settings/Jobs.vue
+++ b/resources/js/pages/settings/Jobs.vue
@@ -295,11 +295,6 @@ onUnmounted(() => {
 
         <SettingsLayout>
             <div class="flex flex-col space-y-6">
-                <HeadingSmall 
-                    title="Queue Workers" 
-                    description="Manage and monitor queue workers for background job processing" 
-                />
-
                 <div class="space-y-4">
                     <Alert>
                         <AlertCircle class="h-4 w-4" />
@@ -308,27 +303,6 @@ onUnmounted(() => {
                             The worker will run with a timeout of 3600 seconds (1 hour).
                         </AlertDescription>
                     </Alert>
-
-                    <div class="flex items-center gap-4">
-                        <Button 
-                            @click="startWorker" 
-                            :disabled="isStarting || isStopping"
-                            variant="default"
-                        >
-                            <Play v-if="!isStarting" class="mr-2 h-4 w-4" />
-                            <Loader2 v-if="isStarting" class="mr-2 h-4 w-4 animate-spin" />
-                            {{ isStarting ? 'Starting...' : 'Start Queue Worker' }}
-                        </Button>
-
-                        <Button 
-                            @click="refreshStatus" 
-                            :disabled="isLoading"
-                            variant="outline"
-                        >
-                            <RefreshCw :class="['h-4 w-4', isLoading ? 'animate-spin' : '']" />
-                            <span class="ml-2">Refresh</span>
-                        </Button>
-                    </div>
 
                     <Alert v-if="statusMessage" :class="{
                         'border-green-500 bg-green-50 dark:bg-green-950/20': statusType === 'success',
@@ -369,7 +343,29 @@ onUnmounted(() => {
                     </div>
 
                     <div class="space-y-4">
-                        <h3 class="text-lg font-semibold">Active Workers</h3>
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-semibold">Active Workers</h3>
+                            <div class="flex items-center gap-4">
+                                <Button 
+                                    @click="startWorker" 
+                                    :disabled="isStarting || isStopping"
+                                    variant="default"
+                                >
+                                    <Play v-if="!isStarting" class="mr-2 h-4 w-4" />
+                                    <Loader2 v-if="isStarting" class="mr-2 h-4 w-4 animate-spin" />
+                                    {{ isStarting ? 'Starting...' : 'Start Queue Worker' }}
+                                </Button>
+
+                                <Button 
+                                    @click="refreshStatus" 
+                                    :disabled="isLoading"
+                                    variant="outline"
+                                >
+                                    <RefreshCw :class="['h-4 w-4', isLoading ? 'animate-spin' : '']" />
+                                    <span class="ml-2">Refresh</span>
+                                </Button>
+                            </div>
+                        </div>
                         
                         <div v-if="workers.length === 0" class="text-muted-foreground">
                             No active workers found. Click "Start Queue Worker" to begin processing jobs.


### PR DESCRIPTION
## Summary
- Removed redundant "Queue Workers" header section from the Jobs settings page
- Repositioned "Start Queue Worker" and "Refresh" buttons inline with "Active Workers" heading for better UI flow
- Streamlined the page layout to reduce unnecessary visual hierarchy

## Changes Made
- Removed the `HeadingSmall` component with "Queue Workers" title and description
- Moved action buttons (Start Queue Worker & Refresh) to the same row as "Active Workers" heading
- Maintained all functionality while improving the visual layout

## Test Plan
- [ ] Navigate to Settings > Jobs page
- [ ] Verify the "Start Queue Worker" button appears next to "Active Workers" heading
- [ ] Test that the Start Queue Worker functionality still works
- [ ] Test that the Refresh button still works
- [ ] Verify the page layout looks clean and organized

🤖 Generated with [Claude Code](https://claude.ai/code)