### PR TITLE
feat: Remove user_id restrictions from archive/unarchive actions

### DIFF
--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -73,11 +73,6 @@ class ConversationsController extends Controller
 
     public function archive(Conversation $conversation)
     {
-        // Ensure the user owns this conversation
-        if ($conversation->user_id !== Auth::id()) {
-            return response()->json(['error' => 'Unauthorized'], 403);
-        }
-
         $conversation->archived = true;
         $conversation->save();
 
@@ -86,11 +81,6 @@ class ConversationsController extends Controller
 
     public function unarchive(Conversation $conversation)
     {
-        // Ensure the user owns this conversation
-        if ($conversation->user_id !== Auth::id()) {
-            return response()->json(['error' => 'Unauthorized'], 403);
-        }
-
         $conversation->archived = false;
         $conversation->save();
 


### PR DESCRIPTION
## Summary
- Removed user ownership checks from archive and unarchive conversation actions
- Any user can now archive/unarchive conversations without restrictions

## Changes
- Removed `user_id !== Auth::id()` checks from `ConversationsController::archive()` and `ConversationsController::unarchive()` methods

🤖 Generated with [Claude Code](https://claude.ai/code)