### PR TITLE
fix: Make header sticky on conversations page

### DIFF
--- a/resources/js/components/AppSidebarHeader.vue
+++ b/resources/js/components/AppSidebarHeader.vue
@@ -15,7 +15,7 @@ withDefaults(
 
 <template>
     <header
-        class="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/70 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4"
+        class="sticky top-0 z-50 flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/70 bg-background px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4"
     >
         <div class="flex items-center gap-2">
             <SidebarTrigger class="-ml-1" />


### PR DESCRIPTION
## Summary
- Fixed the header on the conversations page to stick to the top when scrolling
- Improves user experience by keeping navigation controls always accessible

## Changes
- Added `sticky top-0` classes to make the header stick to the top
- Added `z-50` to ensure proper layering above scrolling content  
- Added `bg-background` to prevent content from showing through the header

## Test plan
- [x] Navigate to the conversations/Claude page
- [x] Scroll down and verify the header stays at the top
- [x] Verify the header has proper background and doesn't show content through it
- [x] Test with both expanded and collapsed sidebar states

🤖 Generated with [Claude Code](https://claude.ai/code)