### PR TITLE
feat: Auto-hide sidebar on mobile when clicking navigation items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "689f4f127feb0",
+    "name": "68a0378944d18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/sidebar';
 import { useConversations } from '@/composables/useConversations';
 import { useRepositories } from '@/composables/useRepositories';
+import { useSidebar } from '@/components/ui/sidebar';
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { BookOpen, GitBranch, Loader2, MessageSquarePlus, Plus } from 'lucide-vue-next';
 import { onMounted, onUnmounted, ref } from 'vue';
@@ -24,6 +25,7 @@ import AppLogo from './AppLogo.vue';
 const page = usePage();
 const { conversations, fetchConversations, startPolling, stopPolling, cleanup } = useConversations();
 const { repositories, fetchRepositories, cloneRepository, loading } = useRepositories();
+const { isMobile, setOpenMobile } = useSidebar();
 
 const showCloneDialog = ref(false);
 const repositoryUrl = ref('');
@@ -67,10 +69,25 @@ const handleCloneRepository = async () => {
 };
 
 const handleRepositoryClick = (repositorySlug: string) => {
+    if (isMobile.value) {
+        setOpenMobile(false);
+    }
     router.visit(`/repository/${repositorySlug}`, {
         preserveScroll: true,
         preserveState: true,
     });
+};
+
+const handleConversationClick = (conversationId: number) => {
+    if (isMobile.value) {
+        setOpenMobile(false);
+    }
+};
+
+const handleLinkClick = () => {
+    if (isMobile.value) {
+        setOpenMobile(false);
+    }
 };
 </script>
 
@@ -80,7 +97,7 @@ const handleRepositoryClick = (repositorySlug: string) => {
             <SidebarMenu>
                 <SidebarMenuItem>
                     <SidebarMenuButton size="lg" as-child>
-                        <Link :href="route('claude')" :preserve-scroll="true" :preserve-state="true">
+                        <Link :href="route('claude')" :preserve-scroll="true" :preserve-state="true" @click="handleLinkClick">
                             <AppLogo />
                         </Link>
                     </SidebarMenuButton>
@@ -93,7 +110,7 @@ const handleRepositoryClick = (repositorySlug: string) => {
                 <SidebarMenu>
                     <SidebarMenuItem>
                         <SidebarMenuButton as-child :is-active="page.url === '/docs'">
-                            <Link href="/docs" :preserve-scroll="true" :preserve-state="true">
+                            <Link href="/docs" :preserve-scroll="true" :preserve-state="true" @click="handleLinkClick">
                                 <BookOpen />
                                 <span>Documentation</span>
                             </Link>
@@ -138,6 +155,7 @@ const handleRepositoryClick = (repositorySlug: string) => {
                                 :preserve-scroll="true"
                                 :preserve-state="true"
                                 class="flex items-center"
+                                @click="handleConversationClick(conversation.id)"
                             >
                                 <MessageSquarePlus />
                                 <div class="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- Automatically closes the sidebar on mobile devices when users click on navigation items
- Improves mobile user experience by maximizing screen space for content
- Applies to conversations, repositories, documentation, and logo links

## Changes Made
- Added `useSidebar` composable import to access mobile state management
- Created `handleRepositoryClick`, `handleConversationClick`, and `handleLinkClick` handlers
- Each handler checks if the device is mobile and closes the sidebar accordingly
- Applied handlers to all navigation links in the sidebar

## Test Plan
- [ ] Test on mobile device or responsive view
- [ ] Click on a conversation - sidebar should close
- [ ] Click on a repository - sidebar should close  
- [ ] Click on Documentation link - sidebar should close
- [ ] Click on logo - sidebar should close
- [ ] Verify desktop behavior remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)