### PR TITLE
Remove cancel button from archive confirmation

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -708,14 +708,6 @@ onUnmounted(() => {
             </Button>
             <div v-if="conversationId && showArchiveConfirm && !isArchived" class="mr-2 flex gap-2">
                 <Button
-                    @click="showArchiveConfirm = false"
-                    variant="outline"
-                    size="sm"
-                    :disabled="isArchiving"
-                >
-                    Cancel
-                </Button>
-                <Button
                     @click="archiveConversation()"
                     variant="destructive"
                     size="sm"


### PR DESCRIPTION
## Summary
- Removed the cancel button from the archive confirmation dialog in the conversations page
- Simplified the UI to only show the "Confirm Archive" button
- Users can still cancel by clicking elsewhere or clicking the archive button again

## Test plan
- [ ] Navigate to a conversation page
- [ ] Click the archive button in the header
- [ ] Verify only "Confirm Archive" button appears (no Cancel button)
- [ ] Verify clicking elsewhere dismisses the confirmation
- [ ] Verify archiving still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)