### PR TITLE
feat: Update PWA with black color scheme and new chat icon

### DIFF
--- a/public/icons/icon-128x128.svg
+++ b/public/icons/icon-128x128.svg
@@ -1,11 +1,15 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad128" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="128" height="128" fill="url(#grad128)" rx="12.8" />
-    <circle cx="64" cy="64" r="44.8" fill="white" />
-    <text x="64" y="64" font-family="Arial, sans-serif" font-size="38.4" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="128" height="128" fill="url(#grad128)" rx="19.20" />
+    <g transform="translate(64, 64)">
+        <path d="M -29.952 -9.984 Q -29.952 -19.968 -19.968 -19.968 L 19.968 -19.968 Q 29.952 -19.968 29.952 -9.984 L 29.952 4.992 Q 29.952 14.976 19.968 14.976 L 4.992 14.976 L -9.984 24.960 L -9.984 14.976 L -19.968 14.976 Q -29.952 14.976 -29.952 4.992 Z" fill="white" stroke="none"/>
+        <circle cx="-14.976" cy="-2.432" r="1.9968" fill="#000000"/>
+        <circle cx="0" cy="-2.432" r="1.9968" fill="#000000"/>
+        <circle cx="14.976" cy="-2.432" r="1.9968" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-144x144.svg
+++ b/public/icons/icon-144x144.svg
@@ -1,11 +1,15 @@
 <svg width="144" height="144" viewBox="0 0 144 144" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad144" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="144" height="144" fill="url(#grad144)" rx="14.4" />
-    <circle cx="72" cy="72" r="50.4" fill="white" />
-    <text x="72" y="72" font-family="Arial, sans-serif" font-size="43.199999999999996" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="144" height="144" fill="url(#grad144)" rx="21.60" />
+    <g transform="translate(72, 72)">
+        <path d="M -33.696 -11.232 Q -33.696 -22.464 -22.464 -22.464 L 22.464 -22.464 Q 33.696 -22.464 33.696 -11.232 L 33.696 5.616 Q 33.696 16.848 22.464 16.848 L 5.616 16.848 L -11.232 28.080 L -11.232 16.848 L -22.464 16.848 Q -33.696 16.848 -33.696 5.616 Z" fill="white" stroke="none"/>
+        <circle cx="-16.848" cy="-2.736" r="2.2464" fill="#000000"/>
+        <circle cx="0" cy="-2.736" r="2.2464" fill="#000000"/>
+        <circle cx="16.848" cy="-2.736" r="2.2464" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-152x152.svg
+++ b/public/icons/icon-152x152.svg
@@ -1,11 +1,15 @@
 <svg width="152" height="152" viewBox="0 0 152 152" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad152" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="152" height="152" fill="url(#grad152)" rx="15.200000000000001" />
-    <circle cx="76" cy="76" r="53.199999999999996" fill="white" />
-    <text x="76" y="76" font-family="Arial, sans-serif" font-size="45.6" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="152" height="152" fill="url(#grad152)" rx="22.80" />
+    <g transform="translate(76, 76)">
+        <path d="M -35.568 -11.856 Q -35.568 -23.712 -23.712 -23.712 L 23.712 -23.712 Q 35.568 -23.712 35.568 -11.856 L 35.568 5.928 Q 35.568 17.784 23.712 17.784 L 5.928 17.784 L -11.856 29.640 L -11.856 17.784 L -23.712 17.784 Q -35.568 17.784 -35.568 5.928 Z" fill="white" stroke="none"/>
+        <circle cx="-17.784" cy="-2.888" r="2.3712" fill="#000000"/>
+        <circle cx="0" cy="-2.888" r="2.3712" fill="#000000"/>
+        <circle cx="17.784" cy="-2.888" r="2.3712" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,11 +1,15 @@
 <svg width="192" height="192" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad192" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="192" height="192" fill="url(#grad192)" rx="19.200000000000003" />
-    <circle cx="96" cy="96" r="67.19999999999999" fill="white" />
-    <text x="96" y="96" font-family="Arial, sans-serif" font-size="57.599999999999994" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="192" height="192" fill="url(#grad192)" rx="28.80" />
+    <g transform="translate(96, 96)">
+        <path d="M -44.928 -14.976 Q -44.928 -29.952 -29.952 -29.952 L 29.952 -29.952 Q 44.928 -29.952 44.928 -14.976 L 44.928 7.488 Q 44.928 22.464 29.952 22.464 L 7.488 22.464 L -14.976 37.440 L -14.976 22.464 L -29.952 22.464 Q -44.928 22.464 -44.928 7.488 Z" fill="white" stroke="none"/>
+        <circle cx="-22.464" cy="-3.648" r="2.9952" fill="#000000"/>
+        <circle cx="0" cy="-3.648" r="2.9952" fill="#000000"/>
+        <circle cx="22.464" cy="-3.648" r="2.9952" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-384x384.svg
+++ b/public/icons/icon-384x384.svg
@@ -1,11 +1,15 @@
 <svg width="384" height="384" viewBox="0 0 384 384" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad384" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="384" height="384" fill="url(#grad384)" rx="38.400000000000006" />
-    <circle cx="192" cy="192" r="134.39999999999998" fill="white" />
-    <text x="192" y="192" font-family="Arial, sans-serif" font-size="115.19999999999999" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="384" height="384" fill="url(#grad384)" rx="57.60" />
+    <g transform="translate(192, 192)">
+        <path d="M -89.856 -29.952 Q -89.856 -59.904 -59.904 -59.904 L 59.904 -59.904 Q 89.856 -59.904 89.856 -29.952 L 89.856 14.976 Q 89.856 44.928 59.904 44.928 L 14.976 44.928 L -29.952 74.880 L -29.952 44.928 L -59.904 44.928 Q -89.856 44.928 -89.856 14.976 Z" fill="white" stroke="none"/>
+        <circle cx="-44.928" cy="-7.296" r="5.9904" fill="#000000"/>
+        <circle cx="0" cy="-7.296" r="5.9904" fill="#000000"/>
+        <circle cx="44.928" cy="-7.296" r="5.9904" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,11 +1,15 @@
 <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad512" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="512" height="512" fill="url(#grad512)" rx="51.2" />
-    <circle cx="256" cy="256" r="179.2" fill="white" />
-    <text x="256" y="256" font-family="Arial, sans-serif" font-size="153.6" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="512" height="512" fill="url(#grad512)" rx="76.8" />
+    <g transform="translate(256, 256)">
+        <path d="M -120 -40 Q -120 -80 -80 -80 L 80 -80 Q 120 -80 120 -40 L 120 20 Q 120 60 80 60 L 20 60 L -40 100 L -40 60 L -80 60 Q -120 60 -120 20 Z" fill="white" stroke="none"/>
+        <circle cx="-60" cy="-10" r="8" fill="#000000"/>
+        <circle cx="0" cy="-10" r="8" fill="#000000"/>
+        <circle cx="60" cy="-10" r="8" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-72x72.svg
+++ b/public/icons/icon-72x72.svg
@@ -1,11 +1,15 @@
 <svg width="72" height="72" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad72" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="72" height="72" fill="url(#grad72)" rx="7.2" />
-    <circle cx="36" cy="36" r="25.2" fill="white" />
-    <text x="36" y="36" font-family="Arial, sans-serif" font-size="21.599999999999998" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="72" height="72" fill="url(#grad72)" rx="10.80" />
+    <g transform="translate(36, 36)">
+        <path d="M -16.848 -5.616 Q -16.848 -11.232 -11.232 -11.232 L 11.232 -11.232 Q 16.848 -11.232 16.848 -5.616 L 16.848 2.808 Q 16.848 8.424 11.232 8.424 L 2.808 8.424 L -5.616 14.040 L -5.616 8.424 L -11.232 8.424 Q -16.848 8.424 -16.848 2.808 Z" fill="white" stroke="none"/>
+        <circle cx="-8.424" cy="-1.368" r="1.1232" fill="#000000"/>
+        <circle cx="0" cy="-1.368" r="1.1232" fill="#000000"/>
+        <circle cx="8.424" cy="-1.368" r="1.1232" fill="#000000"/>
+    </g>
 </svg>

--- a/public/icons/icon-96x96.svg
+++ b/public/icons/icon-96x96.svg
@@ -1,11 +1,15 @@
 <svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
     <defs>
         <linearGradient id="grad96" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+            <stop offset="0%" style="stop-color:#1a1a1a;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#000000;stop-opacity:1" />
         </linearGradient>
     </defs>
-    <rect width="96" height="96" fill="url(#grad96)" rx="9.600000000000001" />
-    <circle cx="48" cy="48" r="33.599999999999994" fill="white" />
-    <text x="48" y="48" font-family="Arial, sans-serif" font-size="28.799999999999997" font-weight="bold" fill="#0ea5e9" text-anchor="middle" dominant-baseline="middle">LC</text>
+    <rect width="96" height="96" fill="url(#grad96)" rx="14.40" />
+    <g transform="translate(48, 48)">
+        <path d="M -22.464 -7.488 Q -22.464 -14.976 -14.976 -14.976 L 14.976 -14.976 Q 22.464 -14.976 22.464 -7.488 L 22.464 3.744 Q 22.464 11.232 14.976 11.232 L 3.744 11.232 L -7.488 18.720 L -7.488 11.232 L -14.976 11.232 Q -22.464 11.232 -22.464 3.744 Z" fill="white" stroke="none"/>
+        <circle cx="-11.232" cy="-1.824" r="1.4976" fill="#000000"/>
+        <circle cx="0" cy="-1.824" r="1.4976" fill="#000000"/>
+        <circle cx="11.232" cy="-1.824" r="1.4976" fill="#000000"/>
+    </g>
 </svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,8 +5,8 @@
   "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "theme_color": "#0ea5e9",
-  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "background_color": "#000000",
   "icons": [
     {
       "src": "/icons/icon-72x72.svg",

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -7,9 +7,9 @@
 
         {{-- PWA Meta Tags --}}
         <link rel="manifest" href="/manifest.json">
-        <meta name="theme-color" content="#0ea5e9">
+        <meta name="theme-color" content="#000000">
         <meta name="apple-mobile-web-app-capable" content="yes">
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black">
         <meta name="apple-mobile-web-app-title" content="LaraChat">
         <meta name="mobile-web-app-capable" content="yes">
 


### PR DESCRIPTION
## Summary
- Updated PWA manifest colors to use black theme (#000000)
- Created modern chat bubble icon with black gradient background
- Updated meta theme-color tags for consistent black theming

## Changes
- Modified `public/manifest.json` to use black for theme_color and background_color
- Redesigned all PWA icons with a sleek black gradient and white chat bubble design
- Updated `resources/views/app.blade.php` meta tags for black theme

## Test plan
- [ ] Install PWA on mobile device and verify black theme appears
- [ ] Check that new chat bubble icon displays correctly
- [ ] Verify status bar uses black styling on iOS devices
- [ ] Test PWA installation on desktop browsers

🤖 Generated with [Claude Code](https://claude.ai/code)