### PR TITLE
docs: Update PR creation instructions to use origin repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,12 @@ Blue code is 19B
   5. NEVER push directly to the default branch
 
 ## PR Creation Command
-When asked to create a PR, use this command:
+When asked to create a PR, use this command (creates PR to ORIGIN repository):
 ```bash
-git checkout -b feature/new-branch && git push -u fork feature/new-branch && gh pr create --base master --head AdamAidenCommet:feature/new-branch --repo CodingCab/LaraChat --title "PR title" --body "PR description"
+git checkout -b feature/new-branch && git push -u origin feature/new-branch && gh pr create --base master --head feature/new-branch --repo CodingCab/LaraChat --title "PR title" --body "PR description"
 ```
 Replace `feature/new-branch` with appropriate branch name, and update title/body as needed.
+**IMPORTANT**: Always create PRs to the ORIGIN repository, not fork.
 
 ## Branch Reset Command
 When asked to reset branch, checkout to master, or similar, run:


### PR DESCRIPTION
## Summary
- Updated AGENTS.md to clarify that PRs should be created to the origin repository
- Modified PR creation command to push to origin instead of fork
- Added explicit note about always creating PRs to origin

## Changes
- Changed push destination from `fork` to `origin` in PR creation command
- Added clarification that PRs should target the origin repository, not fork

🤖 Generated with [Claude Code](https://claude.ai/code)