### PR TITLE
feat: Improve message spacing and mobile responsiveness

### DIFF
--- a/resources/js/components/ChatMessage.vue
+++ b/resources/js/components/ChatMessage.vue
@@ -38,7 +38,7 @@ const toggleRawResponse = () => {
     <div :class="['flex', message.role === 'user' ? 'justify-end' : 'justify-start']">
         <div
             :class="[
-                'max-w-[70%] rounded-2xl px-4 py-2',
+                'max-w-full sm:max-w-[70%] rounded-2xl px-4 py-2',
                 message.role === 'user' ? 'bg-muted text-foreground' : 'border bg-card text-card-foreground',
             ]"
         >

--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -724,7 +724,7 @@ onUnmounted(() => {
         <div class="flex h-[calc(100dvh-4rem)] flex-col bg-background">
             <!-- Chat Messages -->
             <ScrollArea ref="messagesContainer" class="flex-1 p-4">
-                <div class="space-y-4">
+                <div class="space-y-2">
                     <ChatMessage
                         v-for="message in filteredMessages"
                         :key="message.id"
@@ -734,7 +734,7 @@ onUnmounted(() => {
                     />
 
                     <div v-if="isLoading" class="flex justify-start">
-                        <div class="max-w-[70%] rounded-2xl bg-card px-4 py-2 shadow-sm">
+                        <div class="max-w-full sm:max-w-[70%] rounded-2xl bg-card px-4 py-2 shadow-sm">
                             <div class="flex space-x-1">
                                 <div class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:-0.3s]"></div>
                                 <div class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:-0.15s]"></div>


### PR DESCRIPTION
## Summary
- Reduced gap between chat messages for a more compact, readable layout
- Made messages responsive to display full width on mobile devices
- Improved mobile user experience with better space utilization

## Changes
- Changed message spacing from `space-y-4` to `space-y-2` in Claude.vue
- Updated ChatMessage component to use `max-w-full sm:max-w-[70%]` for responsive width
- Applied same responsive pattern to loading indicator for consistency

## Test plan
- [ ] View conversations on desktop - messages should maintain 70% max width
- [ ] View conversations on mobile - messages should use full width
- [ ] Check message spacing looks good on both desktop and mobile
- [ ] Verify loading indicator follows same responsive behavior

🤖 Generated with [Claude Code](https://claude.ai/code)