### PR TITLE
feat: Add environment-based Telescope access control

### DIFF
--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -55,11 +55,23 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, [
-                // Add authorized emails here for production access
-                // 'admin@example.com',
-            ]);
+        Gate::define('viewTelescope', function ($user = null) {
+            // Get allowed emails from .env file
+            $allowedEmails = env('TELESCOPE_ALLOWED_EMAILS', '');
+            
+            // Convert comma-separated emails to array
+            $emails = array_map('trim', explode(',', $allowedEmails));
+            
+            // Remove empty values
+            $emails = array_filter($emails);
+            
+            // If no emails configured, deny access in production
+            if (empty($emails) && $this->app->environment('production')) {
+                return false;
+            }
+            
+            // Check if user email is in the allowed list
+            return $user && in_array($user->email, $emails);
         });
     }
 }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -56,8 +56,8 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
     protected function gate(): void
     {
         Gate::define('viewTelescope', function ($user = null) {
-            // Get allowed emails from .env file
-            $allowedEmails = env('TELESCOPE_ALLOWED_EMAILS', '');
+            // Get allowed emails from config (works with cached config)
+            $allowedEmails = config('telescope.allowed_emails', '');
             
             // Convert comma-separated emails to array
             $emails = array_map('trim', explode(',', $allowedEmails));
@@ -65,8 +65,8 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
             // Remove empty values
             $emails = array_filter($emails);
             
-            // If no emails configured, deny access in production
-            if (empty($emails) && $this->app->environment('production')) {
+            // If no emails configured, deny access in all environments
+            if (empty($emails)) {
                 return false;
             }
             

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -46,6 +46,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Allowed Emails
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value determines which email addresses are allowed
+    | to access Telescope. Separate multiple emails with commas.
+    |
+    */
+
+    'allowed_emails' => env('TELESCOPE_ALLOWED_EMAILS', ''),
+
+    /*
+    |--------------------------------------------------------------------------
     | Telescope Storage Driver
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2025_08_16_141101_create_telescope_entries_table.php
+++ b/database/migrations/2025_08_16_141101_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->onDelete('cascade');
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};


### PR DESCRIPTION
## Summary
- Modified TelescopeServiceProvider to read authorized emails from `TELESCOPE_ALLOWED_EMAILS` environment variable
- Improved security by requiring explicit email configuration for production access
- Added proper null handling for unauthenticated users

## Changes Made
1. **TelescopeServiceProvider Updates**:
   - Changed gate definition to use `TELESCOPE_ALLOWED_EMAILS` environment variable
   - Added comma-separated email parsing with proper trimming and filtering
   - Enhanced security by denying access in production when no emails are configured
   - Improved null safety for unauthenticated users

2. **Migration Added**:
   - Added Telescope database migration file for proper table structure

## Test Plan
- [ ] Verify Telescope access is denied when `TELESCOPE_ALLOWED_EMAILS` is not set in production
- [ ] Test that authorized emails in the environment variable can access Telescope
- [ ] Confirm that unauthorized emails are denied access
- [ ] Validate that comma-separated email lists work correctly
- [ ] Test behavior with whitespace in email configuration

## Configuration
To configure Telescope access, add the following to your `.env` file:
```
TELESCOPE_ALLOWED_EMAILS=admin@example.com,developer@example.com
```

🤖 Generated with [Claude Code](https://claude.ai/code)