### PR TITLE
refactor: Consolidate documentation link in user settings menu

### DIFF
--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -18,7 +18,7 @@ import { useConversations } from '@/composables/useConversations';
 import { useRepositories } from '@/composables/useRepositories';
 import { useSidebar } from '@/components/ui/sidebar';
 import { Link, router, usePage } from '@inertiajs/vue3';
-import { BookOpen, GitBranch, Loader2, MessageSquarePlus, Plus } from 'lucide-vue-next';
+import { GitBranch, Loader2, MessageSquarePlus, Plus } from 'lucide-vue-next';
 import { onMounted, onUnmounted, ref, watch } from 'vue';
 import AppLogo from './AppLogo.vue';
 
@@ -158,19 +158,6 @@ const handleLinkClick = () => {
         </SidebarHeader>
 
         <SidebarContent>
-            <SidebarGroup class="px-2 py-0">
-                <SidebarMenu>
-                    <SidebarMenuItem>
-                        <SidebarMenuButton as-child :is-active="page.url === '/docs'">
-                            <Link href="/docs" :preserve-scroll="true" :preserve-state="true" @click="handleLinkClick">
-                                <BookOpen />
-                                <span>Documentation</span>
-                            </Link>
-                        </SidebarMenuButton>
-                    </SidebarMenuItem>
-                </SidebarMenu>
-            </SidebarGroup>
-
             <SidebarGroup class="px-2 py-0">
                 <div class="flex items-center justify-between">
                     <SidebarGroupLabel>Repositories</SidebarGroupLabel>

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -57,10 +57,10 @@ defineProps<Props>();
     </DropdownMenuGroup>
     <DropdownMenuSeparator />
     <DropdownMenuItem :as-child="true">
-        <a class="flex w-full items-center" href="https://laravel.com/docs/starter-kits#vue" target="_blank" rel="noopener noreferrer">
+        <Link class="flex w-full items-center" href="/docs" :preserve-scroll="true" :preserve-state="true">
             <BookOpen class="mr-2 h-4 w-4" />
             Documentation
-        </a>
+        </Link>
     </DropdownMenuItem>
     <DropdownMenuSeparator />
     <DropdownMenuItem :as-child="true">


### PR DESCRIPTION
## Summary
- Removed standalone documentation link from the sidebar to reduce clutter
- Updated the existing documentation link in user settings menu to point to internal `/docs` route instead of external Laravel docs
- Cleaned up unused BookOpen icon import from AppSidebar component

## Test plan
- [ ] Verify documentation link no longer appears in the sidebar
- [ ] Check that documentation link in user settings dropdown navigates to `/docs`
- [ ] Confirm no console errors or build issues

🤖 Generated with [Claude Code](https://claude.ai/code)