### PR TITLE
feat: Enable Telescope in all environments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/nightwatch": "^1.11",
+        "laravel/telescope": "^5.11",
         "laravel/tinker": "^2.10.1",
         "spatie/ssh": "^1.13",
         "tightenco/ziggy": "^2.4"
@@ -23,7 +24,6 @@
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.18",
         "laravel/sail": "^1.41",
-        "laravel/telescope": "^5.11",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "phpunit/phpunit": "^11.5.3",


### PR DESCRIPTION
## Summary
- Moved Laravel Telescope from dev dependencies to production dependencies
- This allows Telescope to be available in all environments (not just development)
- Access control is maintained through email-based authentication configured via TELESCOPE_ALLOWED_EMAILS

## Test plan
- [ ] Verify Telescope package is available in production builds
- [ ] Test that Telescope access control works correctly with TELESCOPE_ALLOWED_EMAILS configuration
- [ ] Confirm no unauthorized access to Telescope in production

🤖 Generated with [Claude Code](https://claude.ai/code)