### PR TITLE
Fix: Resolve 404 error when fetching .env file

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Repository;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,5 +26,15 @@ class AppServiceProvider extends ServiceProvider
         if (str_starts_with(config('app.url'), 'https://')) {
             \URL::forceScheme('https');
         }
+
+        // Custom route model binding for API routes
+        Route::bind('repository', function ($value) {
+            // If the current route is an API route and value is numeric, bind by ID
+            if (request()->is('api/*') && is_numeric($value)) {
+                return Repository::findOrFail($value);
+            }
+            // Otherwise, use the default behavior (slug)
+            return Repository::where('slug', $value)->firstOrFail();
+        });
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,11 +16,11 @@ Route::middleware(['web', 'auth'])->group(function () {
 
     Route::get('/repositories', [RepositoryController::class, 'index']);
     Route::post('/repositories', [RepositoryController::class, 'store']);
-    Route::delete('/repositories/{repository}', [RepositoryController::class, 'destroy']);
-    Route::post('/repositories/{repository}/pull', [RepositoryController::class, 'pull']);
-    Route::post('/repositories/{repository}/copy-to-hot', [RepositoryController::class, 'copyToHot']);
-    Route::get('/repositories/{repository}/env', [RepositoryController::class, 'getEnvFile']);
-    Route::put('/repositories/{repository}/env', [RepositoryController::class, 'updateEnvFile']);
+    Route::delete('/repositories/{repository}', [RepositoryController::class, 'destroy'])->where('repository', '[0-9]+');
+    Route::post('/repositories/{repository}/pull', [RepositoryController::class, 'pull'])->where('repository', '[0-9]+');
+    Route::post('/repositories/{repository}/copy-to-hot', [RepositoryController::class, 'copyToHot'])->where('repository', '[0-9]+');
+    Route::get('/repositories/{repository}/env', [RepositoryController::class, 'getEnvFile'])->where('repository', '[0-9]+');
+    Route::put('/repositories/{repository}/env', [RepositoryController::class, 'updateEnvFile'])->where('repository', '[0-9]+');
 
     Route::get('/conversations', [ConversationsController::class, 'index']);
     Route::post('/conversations', [ConversationsController::class, 'store']);


### PR DESCRIPTION
## Summary
- Fixed 404 error when opening the environment variables modal in RepositoryDashboard
- Resolved route model binding conflict between slug-based web routes and ID-based API routes

## Problem
The Repository model uses `slug` as the route key for web routes, but the frontend was sending numeric IDs to API endpoints. This mismatch caused Laravel to look for repositories by slug using numeric IDs, resulting in 404 errors.

## Solution
Added custom route model binding in `AppServiceProvider` that:
- Uses ID-based lookup for API routes when the parameter value is numeric
- Maintains slug-based lookup for web routes
- Added numeric constraints to repository API routes for clarity

## Test Plan
- [x] Open a repository dashboard
- [x] Click the "Environment" button
- [x] Verify the .env file loads without 404 error
- [x] Test editing and saving .env file content
- [x] Verify other repository API endpoints still work (pull, delete, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)