### PR TITLE
fix: Update processing indicator to use only conversation state

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -836,7 +836,7 @@ onUnmounted(() => {
                         :show-raw-responses="false"
                     />
 
-                    <div v-if="isLoading || conversation?.is_processing" class="flex justify-start">
+                    <div v-if="conversation?.is_processing" id="processing-indicator" class="flex justify-start">
                         <div class="max-w-full sm:max-w-[70%] rounded-2xl bg-card px-4 py-2 shadow-sm">
                             <div class="flex space-x-1">
                                 <div class="h-2 w-2 animate-bounce rounded-full bg-muted-foreground/50 [animation-delay:-0.3s]"></div>


### PR DESCRIPTION
## Summary
- Remove dependency on `isLoading` for processing indicator
- Use only `conversation?.is_processing` to control visibility  
- Add `id="processing-indicator"` for easier element reference

## Details
The processing indicator in Claude.vue was using both `isLoading` and `conversation?.is_processing` to determine visibility. This change simplifies the logic to rely solely on the conversation state, ensuring consistent state management through the conversation object rather than mixing local and remote state.

## Test plan
- [ ] Verify processing indicator appears when conversation is processing
- [ ] Verify processing indicator disappears when processing completes
- [ ] Confirm no visual regression in the chat interface

🤖 Generated with [Claude Code](https://claude.ai/code)