### PR TITLE
feat: Add mode toggle to conversations page header

### DIFF
--- a/app/Http/Controllers/ClaudeController.php
+++ b/app/Http/Controllers/ClaudeController.php
@@ -91,6 +91,7 @@ class ClaudeController extends Controller
             'sessionFilename' => 'nullable|string',
             'conversationId' => 'nullable|integer|exists:conversations,id',
             'repositoryPath' => 'nullable|string',
+            'mode' => 'nullable|string|in:plan,bypassPermissions',
         ]);
 
         $conversationId = $request->input('conversationId');
@@ -116,6 +117,7 @@ class ClaudeController extends Controller
                 'is_processing' => true,
                 'claude_session_id' => $request->input('sessionId'),
                 'project_directory' => $request->input('repositoryPath'),
+                'mode' => $request->input('mode', 'plan'),
             ]);
             
             $conversationId = $conversation->id;

--- a/app/Http/Controllers/ConversationsController.php
+++ b/app/Http/Controllers/ConversationsController.php
@@ -176,6 +176,41 @@ class ConversationsController extends Controller
     }
 
     /**
+     * Update conversation
+     * 
+     * Update conversation properties like mode
+     * 
+     * @authenticated
+     * 
+     * @urlParam conversation integer required The ID of the conversation. Example: 1
+     * @bodyParam mode string required The conversation mode. Example: plan
+     * 
+     * @response 200 scenario="Success" {
+     *   "message": "Conversation updated successfully"
+     * }
+     * 
+     * @response 403 scenario="Unauthorized" {
+     *   "error": "Unauthorized"
+     * }
+     */
+    public function update(Request $request, Conversation $conversation)
+    {
+        // Check if user owns this conversation
+        if ($conversation->user_id !== Auth::id()) {
+            abort(403, 'Unauthorized');
+        }
+
+        $request->validate([
+            'mode' => 'required|string|in:plan,bypassPermissions',
+        ]);
+
+        $conversation->mode = $request->input('mode');
+        $conversation->save();
+
+        return response()->json(['message' => 'Conversation updated successfully']);
+    }
+
+    /**
      * List archived conversations
      * 
      * Get a list of all archived conversations for the authenticated user

--- a/resources/js/types/claude.ts
+++ b/resources/js/types/claude.ts
@@ -21,4 +21,5 @@ export interface ClaudeApiRequest {
     sessionFilename: string;
     repositoryPath?: string;
     conversationId?: number;
+    mode?: string;
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ Route::middleware(['web', 'auth'])->group(function () {
     Route::get('/conversations', [ConversationsController::class, 'index']);
     Route::post('/conversations', [ConversationsController::class, 'store']);
     Route::get('/conversations/archived', [ConversationsController::class, 'archived']);
+    Route::put('/conversations/{conversation}', [ConversationsController::class, 'update']);
     Route::post('/conversations/{conversation}/archive', [ConversationsController::class, 'archive']);
     Route::post('/conversations/{conversation}/unarchive', [ConversationsController::class, 'unarchive']);
 


### PR DESCRIPTION
## Summary
- Added mode toggle (Coding/Planning) to the conversations page header
- Allows users to switch between coding and planning modes for active conversations
- Mode persists with the conversation and syncs across page loads

## Changes
- Added mode toggle UI to Claude.vue page header with Coding/Planning Mode buttons
- Added update endpoint to ConversationsController for changing conversation mode  
- Updated ClaudeController to handle mode parameter when creating conversations via API
- Added selectedMode state management and synchronization with conversation mode
- Mode toggle only appears for active (non-archived) conversations

## Test Plan
- [x] Build frontend assets successfully
- [ ] Test mode toggle appears only for active conversations
- [ ] Verify mode changes are saved to backend
- [ ] Confirm mode persists when switching between conversations
- [ ] Test that new conversations use the selected mode

🤖 Generated with [Claude Code](https://claude.ai/code)