### PR TITLE
feat: Move planning mode button to left and set as default

### DIFF
--- a/resources/js/pages/RepositoryDashboard.vue
+++ b/resources/js/pages/RepositoryDashboard.vue
@@ -53,7 +53,7 @@ const showEnvModal = ref(false);
 const showDeleteModal = ref(false);
 const deleteConfirmation = ref('');
 const isDeleting = ref(false);
-const selectedMode = ref<'coding' | 'planning'>('coding');
+const selectedMode = ref<'coding' | 'planning'>('planning');
 
 const startChatWithMessage = (message?: string) => {
     const finalMessage = message || messageInput.value.trim();
@@ -159,15 +159,6 @@ const handleDelete = async () => {
                         <div class="flex items-center justify-center gap-2">
                             <div class="inline-flex rounded-lg border p-1">
                                 <Button
-                                    @click="selectedMode = 'coding'"
-                                    :variant="selectedMode === 'coding' ? 'default' : 'ghost'"
-                                    size="sm"
-                                    class="gap-2"
-                                >
-                                    <Code2 class="h-4 w-4" />
-                                    Coding Mode
-                                </Button>
-                                <Button
                                     @click="selectedMode = 'planning'"
                                     :variant="selectedMode === 'planning' ? 'default' : 'ghost'"
                                     size="sm"
@@ -175,6 +166,15 @@ const handleDelete = async () => {
                                 >
                                     <Lightbulb class="h-4 w-4" />
                                     Planning Mode
+                                </Button>
+                                <Button
+                                    @click="selectedMode = 'coding'"
+                                    :variant="selectedMode === 'coding' ? 'default' : 'ghost'"
+                                    size="sm"
+                                    class="gap-2"
+                                >
+                                    <Code2 class="h-4 w-4" />
+                                    Coding Mode
                                 </Button>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Reordered mode selection buttons with Planning Mode positioned on the left
- Changed default selection from Coding Mode to Planning Mode
- Improves user experience by prioritizing planning before implementation

## Changes
- Updated `RepositoryDashboard.vue` to swap button positions
- Modified default value of `selectedMode` from 'coding' to 'planning'

## Test Plan
- [x] Verify Planning Mode button appears on the left
- [x] Verify Planning Mode is selected by default when page loads
- [x] Verify mode switching still works correctly
- [x] Verify correct mode is passed to Claude API when starting conversation

🤖 Generated with [Claude Code](https://claude.ai/code)