### PR TITLE
Remove text labels from mode selection buttons

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -814,19 +814,17 @@ onUnmounted(() => {
                     @click="updateConversationMode('coding')"
                     :variant="selectedMode === 'coding' ? 'default' : 'ghost'"
                     size="sm"
-                    class="gap-2"
+                    :title="'Coding Mode'"
                 >
                     <Code class="h-4 w-4" />
-                    Coding Mode
                 </Button>
                 <Button
                     @click="updateConversationMode('planning')"
                     :variant="selectedMode === 'planning' ? 'default' : 'ghost'"
                     size="sm"
-                    class="gap-2"
+                    :title="'Planning Mode'"
                 >
                     <MapPin class="h-4 w-4" />
-                    Planning Mode
                 </Button>
             </div>
             <Button


### PR DESCRIPTION
## Summary
- Removed text labels ("Coding Mode" and "Planning Mode") from the mode selection buttons
- Buttons now display only icons for a cleaner, more compact UI
- Added tooltips to show mode names on hover for better UX

## Changes
- Removed text labels from coding/planning mode buttons in Claude.vue
- Added title attributes for tooltips
- Removed unnecessary gap-2 class since text is removed

## Test Plan
- [x] Mode buttons display only icons (Code icon for coding, MapPin for planning)
- [x] Hovering over buttons shows appropriate tooltips
- [x] Mode switching functionality remains unchanged
- [x] UI looks cleaner especially on smaller screens

🤖 Generated with [Claude Code](https://claude.ai/code)