### PR TITLE
fix: Update Ask Lara to use blank repository and improve archiving logic

### DIFF
--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -146,9 +146,9 @@ const handleAskLara = () => {
     if (isMobile.value) {
         setOpenMobile(false);
     }
-    // Create a new conversation in planning mode with repositories/base as directory
+    // Create a new conversation in planning mode with blank repository
     const message = btoa('Hello Lara! I need help with my project.');
-    router.visit(`/claude/new?repository=repositories/base&mode=plan&message=${message}`, {
+    router.visit(`/claude/new?repository=&mode=plan&message=${message}`, {
         preserveScroll: true,
         preserveState: true,
     });


### PR DESCRIPTION
## Summary
- Ask Lara button now creates conversations with blank repository in planning mode
- Archive conversation only dispatches DeleteProjectDirectoryJob for blank repositories  
- ConversationController enforces repository requirement for non-planning modes

## Changes Made
1. **AppSidebar.vue**: Updated `handleAskLara` function to pass blank repository parameter instead of `repositories/base`
2. **ConversationsController.php**: 
   - Added validation in `store` method to only allow blank repositories in planning mode
   - Modified `archive` method to only dispatch cleanup job for blank repository conversations

## Test Plan
- [x] Verify Ask Lara button creates conversation with blank repository
- [x] Confirm archiving only cleans up directories for blank repository conversations
- [x] Test that non-planning mode requires repository specification
- [x] Code passes linting (with pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.ai/code)